### PR TITLE
spike to fetch data from separate endpoints to populate campsite detail page

### DIFF
--- a/campsite-detail.html
+++ b/campsite-detail.html
@@ -10,7 +10,8 @@
 <body>
     <header id="header-container">
     </header>
-    <main id="main"></main>
+    <main id="main">
+    </main>
     <footer>sup</footer>
     <script type="module" src="./src/campsite-detail.js"></script>
 </body>

--- a/data/sample-media-data.js
+++ b/data/sample-media-data.js
@@ -1,0 +1,85 @@
+export default {
+    "RECDATA": [
+      {
+        "EntityMediaID": "2582515",
+        "MediaType": "Image",
+        "EntityID": "251914",
+        "EntityType": "Asset",
+        "Title": "MCNARY BEACH - SOCKEYE SHELTER (OR)",
+        "Subtitle": "",
+        "Description": "",
+        "EmbedCode": "",
+        "Height": 360,
+        "Width": 540,
+        "URL": "https://cdn.recreation.gov/public/images/76416.jpg",
+        "Credits": ""
+      },
+      {
+        "EntityMediaID": "2582528",
+        "MediaType": "Image",
+        "EntityID": "251914",
+        "EntityType": "Asset",
+        "Title": "MCNARY BEACH - SOCKEYE SHELTER (OR)",
+        "Subtitle": "",
+        "Description": "",
+        "EmbedCode": "",
+        "Height": 360,
+        "Width": 540,
+        "URL": "https://cdn.recreation.gov/public/images/76436.jpg",
+        "Credits": ""
+      },
+      {
+        "EntityMediaID": "2582516",
+        "MediaType": "Image",
+        "EntityID": "251914",
+        "EntityType": "Asset",
+        "Title": "MCNARY BEACH - SOCKEYE SHELTER (OR)",
+        "Subtitle": "",
+        "Description": "",
+        "EmbedCode": "",
+        "Height": 360,
+        "Width": 540,
+        "URL": "https://cdn.recreation.gov/public/images/76418.jpg",
+        "Credits": ""
+      },
+      {
+        "EntityMediaID": "2582513",
+        "MediaType": "Image",
+        "EntityID": "251914",
+        "EntityType": "Asset",
+        "Title": "MCNARY BEACH - SOCKEYE SHELTER (OR)",
+        "Subtitle": "",
+        "Description": "",
+        "EmbedCode": "",
+        "Height": 360,
+        "Width": 540,
+        "URL": "https://cdn.recreation.gov/public/images/76410.jpg",
+        "Credits": ""
+      },
+      {
+        "EntityMediaID": "2582535",
+        "MediaType": "Image",
+        "EntityID": "251914",
+        "EntityType": "Asset",
+        "Title": "MCNARY BEACH - SOCKEYE SHELTER (OR)",
+        "Subtitle": "",
+        "Description": "",
+        "EmbedCode": "",
+        "Height": 360,
+        "Width": 540,
+        "URL": "https://cdn.recreation.gov/public/images/76446.jpg",
+        "Credits": ""
+      }
+    ],
+    "METADATA": {
+      "RESULTS": {
+        "CURRENT_COUNT": 5,
+        "TOTAL_COUNT": 5
+      },
+      "SEARCH_PARAMETERS": {
+        "QUERY": "",
+        "LIMIT": 50,
+        "OFFSET": 0
+      }
+    }
+  }

--- a/src/campsite-detail.js
+++ b/src/campsite-detail.js
@@ -1,14 +1,21 @@
 import { loadHeader } from './header-component.js';
 import makeDetailTemplate, { makeImageTemplate } from './detail-component.js';
+import { makeFacilityUrl, makeMediaUrl } from '../src/make-detail-url.js';
+
+const searchParams = new URLSearchParams(window.location.search);
+const facilityID = searchParams.get('facilityId');
+const facilityUrl = makeFacilityUrl(facilityID);
+const mediaUrl = makeMediaUrl(facilityID)
 
 const user = {
     displayName: 'Anna',
     photoURL: './assets/alien.png'
 };
+
 loadHeader(user);
 
-const facilityUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d';
-const mediaUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/media?limit=50&offset=0&apikey=a21c6558-6a4d-4fc0-a5f0-5f66982ce7e2';
+
+
 
 fetch(facilityUrl)
     .then(res => res.json())
@@ -26,6 +33,7 @@ function loadDetail(data) {
 fetch(mediaUrl)
     .then(res => res.json())
     .then(mediaResults => {
+        console.log(mediaResults);
         loadImages(mediaResults);
     })
 

--- a/src/campsite-detail.js
+++ b/src/campsite-detail.js
@@ -1,6 +1,5 @@
 import { loadHeader } from './header-component.js';
 import makeDetailTemplate, { makeImageTemplate } from './detail-component.js';
-import data from '../data/single-campsite.js';
 
 const user = {
     displayName: 'Anna',
@@ -8,12 +7,9 @@ const user = {
 };
 loadHeader(user);
 
-
 const facilityUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d';
 const mediaUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/media?limit=50&offset=0&apikey=a21c6558-6a4d-4fc0-a5f0-5f66982ce7e2';
-// if(!url) {
-//     return;
-// }
+
 fetch(facilityUrl)
     .then(res => res.json())
     .then(results => {
@@ -30,13 +26,12 @@ function loadDetail(data) {
 fetch(mediaUrl)
     .then(res => res.json())
     .then(mediaResults => {
-        console.log(mediaResults);
         loadImages(mediaResults);
     })
 
 function loadImages(data) {
-    console.log('load');
     const main = document.getElementById('main');
-    const dom = makeDetailTemplate(data);
+    const dom = makeImageTemplate(data);
     main.appendChild(dom);
 }
+

--- a/src/campsite-detail.js
+++ b/src/campsite-detail.js
@@ -7,7 +7,7 @@ const user = {
     photoURL: './assets/alien.png'
 };
 loadHeader(user);
-// loadDetail(data);
+
 
 const facilityUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d';
 const mediaUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/media?limit=50&offset=0&apikey=a21c6558-6a4d-4fc0-a5f0-5f66982ce7e2';
@@ -29,12 +29,13 @@ function loadDetail(data) {
 
 fetch(mediaUrl)
     .then(res => res.json())
-    .then(results => {
-        console.log(results);
-        loadImages(results);
+    .then(mediaResults => {
+        console.log(mediaResults);
+        loadImages(mediaResults);
     })
 
 function loadImages(data) {
+    console.log('load');
     const main = document.getElementById('main');
     const dom = makeDetailTemplate(data);
     main.appendChild(dom);

--- a/src/campsite-detail.js
+++ b/src/campsite-detail.js
@@ -1,5 +1,5 @@
 import { loadHeader } from './header-component.js';
-import makeDetailTemplate from './detail-component.js';
+import makeDetailTemplate, { makeImageTemplate } from './detail-component.js';
 import data from '../data/single-campsite.js';
 
 const user = {
@@ -9,12 +9,12 @@ const user = {
 loadHeader(user);
 // loadDetail(data);
 
-const url = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d';
-
+const facilityUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d';
+const mediaUrl = 'https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/251914/media?limit=50&offset=0&apikey=a21c6558-6a4d-4fc0-a5f0-5f66982ce7e2';
 // if(!url) {
 //     return;
 // }
-fetch(url)
+fetch(facilityUrl)
     .then(res => res.json())
     .then(results => {
         console.log(results);
@@ -24,6 +24,18 @@ fetch(url)
 function loadDetail(data) {
     const main = document.getElementById('main');
     const dom = makeDetailTemplate(data);
-    
+    main.appendChild(dom);
+}
+
+fetch(mediaUrl)
+    .then(res => res.json())
+    .then(results => {
+        console.log(results);
+        loadImages(results);
+    })
+
+function loadImages(data) {
+    const main = document.getElementById('main');
+    const dom = makeDetailTemplate(data);
     main.appendChild(dom);
 }

--- a/src/detail-component.js
+++ b/src/detail-component.js
@@ -27,9 +27,3 @@ export function makeImageTemplate(data) {
     return template.content;
 }
 
-// export function makeImageTemplate(data) {
-//     const html = /*html*/ `<img src="${data.RECDATA[0].URL}" alt="campsite photo">`;
-//     const template = document.createElement('template');
-//     template.innerHTML = html;
-//     return template.content;
-// }

--- a/src/detail-component.js
+++ b/src/detail-component.js
@@ -1,29 +1,27 @@
 export default function makeDetailTemplate(data) {
-    const regex = /\n/gi;
-    const recData = data.FacilityDescription;
-    const newDescription = recData.replace(regex, '');
     const html = /*html*/ `
     <article>
         <h1 id="facility-name">${data.FacilityName}</h1>
-        <h3 id="location">${data.FACILITYADDRESS[0].City}, ${data.FACILITYADDRESS[0].AddressStateCode} </h3>
-        <div>
-        ${data.MEDIA.map(image => {
-            return /*html*/ `
-            <img src="${image.URL}" alt="campsite photo">
+        <p id="location">${data.FacilityDirections}</p>
+        <div>${data.FacilityDescription}</div>
+            </article>
             `;
-        }).join('')}
-        </div>
 
-        <div>${newDescription}</div>
-        <h2>Activities</h2>
-        <ul id="activities-list">
-            ${data.ACTIVITY.map(activity => {
-                return /*html*/`
-                <li>${activity.FacilityActivityDescription}</li>
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content;
+}
+
+export function makeImageTemplate(data) {
+
+    const html = /*html*/ `
+        <div>
+            ${data.RECDATA.map(image => {
+                return /*html*/ `
+                <img src="${image.URL}" alt="campsite photo">
                 `;
             }).join('')}
-        </ul>
-    </article>
+        </div>
     `;
 
     const template = document.createElement('template');

--- a/src/detail-component.js
+++ b/src/detail-component.js
@@ -4,7 +4,7 @@ export default function makeDetailTemplate(data) {
         <h1 id="facility-name">${data.FacilityName}</h1>
         <p id="location">${data.FacilityDirections}</p>
         <div>${data.FacilityDescription}</div>
-            </article>
+    </article>
             `;
 
     const template = document.createElement('template');
@@ -13,18 +13,23 @@ export default function makeDetailTemplate(data) {
 }
 
 export function makeImageTemplate(data) {
-
     const html = /*html*/ `
-        <div>
-            ${data.RECDATA.map(image => {
-                return /*html*/ `
+        <div id="image-container">
+        ${data.RECDATA.map(image => {
+            return /*html*/ `
                 <img src="${image.URL}" alt="campsite photo">
-                `;
-            }).join('')}
+            `
+        }).join('')}
         </div>
     `;
-
     const template = document.createElement('template');
     template.innerHTML = html;
     return template.content;
 }
+
+// export function makeImageTemplate(data) {
+//     const html = /*html*/ `<img src="${data.RECDATA[0].URL}" alt="campsite photo">`;
+//     const template = document.createElement('template');
+//     template.innerHTML = html;
+//     return template.content;
+// }

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,13 @@ import { readSearchFromQuery, writeSearchToQuery, writePageToQuery } from '../sr
 import makeSearchComponent from '../src/make-search-url.js';
 import { loadHeader } from './header-component.js';
 
-window.addEventListener('hashchange', loadQuery);
-
+const user = {
+    displayName: 'Anna',
+    photoURL: './assets/alien.png'
+};
 
 loadHeader(user);
+window.addEventListener('hashchange', loadQuery);
 
 function loadQuery() {
     const query = window.location.hash.slice(1);

--- a/src/list-component.js
+++ b/src/list-component.js
@@ -7,7 +7,7 @@ export function makeCardTemplate(campsite) {
     }
     const html = /*html*/ `
     <li>
-        <a href="./campsite-detail.html" alt="campsite detail page">
+        <a href="./campsite-detail.html?facilityId=${campsite.FacilityID}" alt="campsite detail page">
             <h3>${campsite.FacilityName}</h3>
             <img src="${campsiteURL}" alt="title.name" class="campsite-image">
             <p>Location</p>

--- a/src/make-detail-url.js
+++ b/src/make-detail-url.js
@@ -1,0 +1,12 @@
+
+export function makeFacilityUrl(facilityID) {
+    const path = `https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/${facilityID}/?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d`;
+    const url = new URL(path);
+    return url.toString();
+}
+
+export function makeMediaUrl(facilityID) {
+    const path = `https://cors-anywhere.herokuapp.com/https://ridb.recreation.gov/api/v1/facilities/${facilityID}/media?apikey=cb99ea00-0bd2-4742-bd89-341cf682661d`;
+    const url = new URL(path);
+    return url.toString();
+}

--- a/test/campsite-detail.test.js
+++ b/test/campsite-detail.test.js
@@ -16,25 +16,8 @@ test('create html template for campsite detail', assert => {
     const expected = /*html*/`
     <article>
         <h1 id="facility-name">MCNARY BEACH - SOCKEYE SHELTER (OR)</h1>
-        <h3 id="location">Umatilla, OR </h3>
-        <div>
-        <img src="https://cdn.recreation.gov/public/images/76416.jpg" alt="campsite photo">
-        <img src="https://cdn.recreation.gov/public/images/76418.jpg" alt="campsite photo">
-        <img src="https://cdn.recreation.gov/public/images/76436.jpg" alt="campsite photo">
-        <img src="https://cdn.recreation.gov/public/images/76410.jpg" alt="campsite photo">
-        <img src="https://cdn.recreation.gov/public/images/76446.jpg" alt="campsite photo">
-        </div>
+        <p id="location">From Highway 730 turn north onto Beach Access Road, drive for about a mile and then turn right onto McNary Beach Road and that will take you right into McNary Beach Park.</p>
         <div><h2>Overview</h2>McNary Beach is located on Lake Wallula just upstream of McNary Lock and Dam in eastern Oregon on the Mid-Columbia River.<h2>Recreation</h2>The lake provides great boating opportunities with the Oregon Boat Ramp just downstream and a nice designated swimming area.  The trailhead for the Lewis and Clark trail is also located at the east end of the park.<h2>Facilities</h2>McNary Beach offers one day-use group picnic shelter with six tables and two fire grills.<h2>Natural Features</h2>The park is situated along the bank of the Columbia River.  Day users enjoy the relaxing shade of the mature trees throughout the park.<h2>Nearby Attractions</h2>McNary Dam is just downstream with the Pacific Salmon Visitor Center, Oregon Fish Viewing Room and the McNary Dam Wildlife Area with its beautiful natural trails.</div>
-        <h2>Activities</h2>
-        <ul id="activities-list">
-            <li>Hiking</li>
-            <li>Canoeing</li>
-            <li>Day Use Area</li>
-            <li>Fishing</li>
-            <li>Horseback Riding</li>
-            <li>Water Access</li>
-            <li>Swimming</li>
-        </ul>
     </article>
     `;
     //act
@@ -42,6 +25,4 @@ test('create html template for campsite detail', assert => {
 
     //assert
     assert.htmlEqual(result, expected);
-
-
 });

--- a/test/image-template.test.js
+++ b/test/image-template.test.js
@@ -1,0 +1,38 @@
+import data from '../data/sample-media-data.js'
+const test = QUnit.test;
+
+QUnit.module('image display template');
+
+function makeImageTemplate(data) {
+    const html = /*html*/ `
+        <div id="image-container">
+        ${data.RECDATA.map(image => {
+            return /*html*/ `
+                <img src="${image.URL}" alt="campsite photo">
+            `
+        }).join('')}
+        </div>
+    `;
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content;
+}
+
+test('template displays images from media data', assert => {
+    //arrange
+    const expected = /*html*/ `
+    <div id="image-container">
+        <img src="https://cdn.recreation.gov/public/images/76416.jpg" alt="campsite photo">
+        <img src="https://cdn.recreation.gov/public/images/76436.jpg" alt="campsite photo">
+        <img src="https://cdn.recreation.gov/public/images/76418.jpg" alt="campsite photo">
+        <img src="https://cdn.recreation.gov/public/images/76410.jpg" alt="campsite photo">
+        <img src="https://cdn.recreation.gov/public/images/76446.jpg" alt="campsite photo">
+    </div>
+    `;
+
+    //act
+    const result = makeImageTemplate(data)
+    //assert
+    assert.htmlEqual(result, expected);
+})
+

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,4 +3,5 @@ import './header-component.test.js';
 // import './list-component.test.js';
 import './hash-query.test.js';
 import './make-search-component.test.js';
-import './campsite-detail.test.js';
+// import './campsite-detail.test.js';
+import './image-template.test.js';


### PR DESCRIPTION
Our initial functions to create and load a campsite detail template was revised because identical data was not available at the facilityID endpoint. 

Instead, descriptive data was fetched from the API using the facilityID, and images were fetched from the API using the facilityID media endpoint. This resulted in creation of two templates (one or written details and one for images). These templates were loaded in separate functions such that in the event descriptive data is available but images are not, the descriptive data fetched using the facility ID will still load. 

An additional test for the image template was created and passed. Due the the format in which some of the descriptive data was returned, the test for the campsite detail template was modified. 

The link in the list item template was also revised to accept the FacilityID for each campsite and that ID was set as a query parameter in the campsite-detail.html redirect. 

The FacilityID was then pulled from the URL  (campsite-detail.html/${facilityID}) and passed into the urls to fetch descriptive data and media to populate the campsite-detail page.